### PR TITLE
Add scheduled task execution endpoint and export function from scheduler

### DIFF
--- a/feature-tracker/src/app/api/testing/manual/route.js
+++ b/feature-tracker/src/app/api/testing/manual/route.js
@@ -1,0 +1,13 @@
+import { runMyScheduledTask } from "@/utils/scheduler";
+import { NextResponse } from "next/server";
+
+export async function GET(request) {
+    try {
+        // Call the function to run your scheduled task
+        await runMyScheduledTask();
+        return new NextResponse("Scheduled task executed successfully", { status: 200 });
+    } catch (error) {
+        console.error("Error executing scheduled task:", error);
+        return new NextResponse("Error executing scheduled task", { status: 500 });
+    }
+}

--- a/feature-tracker/src/utils/scheduler.js
+++ b/feature-tracker/src/utils/scheduler.js
@@ -1,6 +1,7 @@
 import cron from 'node-cron';
 
 let taskRunning = false;
+const delay = ms => new Promise(resolve => setTimeout(resolve, ms))
 
 const runMyScheduledTask = async () => {
   if (taskRunning) {
@@ -20,6 +21,8 @@ const runMyScheduledTask = async () => {
     taskRunning = false;
   }
 };
+
+export { runMyScheduledTask }; // Export the function for external use
 
 let schedulerStarted = false; // Flag to ensure scheduler only starts once
 


### PR DESCRIPTION
This pull request introduces a new API route to manually trigger a scheduled task and adds an export for the task-running function to enable external usage. Below are the key changes:

### API Enhancements:
* Added a new `GET` endpoint in `feature-tracker/src/app/api/testing/manual/route.js` to manually trigger the `runMyScheduledTask` function. The endpoint handles success and error responses appropriately.

### Utility Updates:
* Exported the `runMyScheduledTask` function from `feature-tracker/src/utils/scheduler.js` to make it accessible for external use.
* Added a `delay` utility function in `feature-tracker/src/utils/scheduler.js` for potential use in asynchronous operations.