### PR TITLE
Update app strings display name and enhance XML diff check for updates

### DIFF
--- a/feature-tracker/src/app/consts.js
+++ b/feature-tracker/src/app/consts.js
@@ -1,5 +1,5 @@
 export const typeDisplayNameMap = {
-    'strings': 'New strings added',
+    'strings': 'Updated app strings',
     'appversion-android': 'New android app version',
     'appversion-ios': 'New ios app version',
     'sitemap': 'Updated sitemaps',

--- a/feature-tracker/src/utils/tasks/apps/appVersions/compareAndUpdateDB.js
+++ b/feature-tracker/src/utils/tasks/apps/appVersions/compareAndUpdateDB.js
@@ -35,7 +35,11 @@ export default async function compareAndUpdateDB(stringsXMLPath, appId) {
 
     const diffOptions = { context: 3 };
     const diff = createPatch('strings.xml', currentStrings, newStrings, 'Current Strings (XML)', 'New Strings (XML)', diffOptions);
-    
+    // Check if the patch has any actual differences apart from the header
+    if (diff.split('\n').length <= 5) {
+        console.log("No changes detected in the strings XML file.");
+        return; // No changes to update
+    }
     // Update the file with the new strings
     try {
         await fs.writeFile(currentStringsFilePath, newStrings, 'utf-8'); // Changed to async


### PR DESCRIPTION
This pull request includes updates to improve the clarity of string descriptions and enhance the functionality of the `compareAndUpdateDB` utility function. The most important changes include updating the display name for string-related changes and adding a check to skip updates when no meaningful differences are detected in the XML file.

### Updates to string descriptions:
* [`feature-tracker/src/app/consts.js`](diffhunk://#diff-d7124daff8bd39683ad7316cce9bda177e730a3a9abebc224f480e96ea7e6237L2-R2): Updated the display name for the `strings` type from "New strings added" to "Updated app strings" for improved clarity.

### Enhancements to `compareAndUpdateDB` utility:
* [`feature-tracker/src/utils/tasks/apps/appVersions/compareAndUpdateDB.js`](diffhunk://#diff-17a1b3af17284561f54feac10d81313edc686dcec4f63ad0a582ab84eff50e35L38-R42): Added a check to detect whether the generated patch contains meaningful differences. If the patch only includes the header (i.e., fewer than 5 lines), the function logs "No changes detected in the strings XML file." and skips the update process.