### PR TITLE
Update navigation URLs in claudeStringsController and perplexityStrin…

### DIFF
--- a/feature-tracker/src/utils/tasks/web/claudeStrings/controller.js
+++ b/feature-tracker/src/utils/tasks/web/claudeStrings/controller.js
@@ -55,7 +55,7 @@ export default async function claudeStringsController() {
         page.on('response', handleResponse);
 
         // Navigate to claude and wait for network to be idle
-        await page.goto("https://claude.ai/", { waitUntil: 'networkidle', timeout: 60000 });
+        await page.goto("https://claude.ai/new", { waitUntil: 'networkidle', timeout: 60000 });
 
         // Wait for all response processing promises to resolve
         // This ensures all JS files are processed before proceeding

--- a/feature-tracker/src/utils/tasks/web/perplexityStrings/controller.js
+++ b/feature-tracker/src/utils/tasks/web/perplexityStrings/controller.js
@@ -55,7 +55,7 @@ export default async function perplexityStringsController() {
         page.on('response', handleResponse);
 
         // Navigate to perplexity and wait for network to be idle
-        await page.goto("https://perplexity.ai/", { waitUntil: 'networkidle', timeout: 60000 });
+        await page.goto("https://www.perplexity.ai/", { waitUntil: 'networkidle', timeout: 60000 });
 
         // Wait for all response processing promises to resolve
         // This ensures all JS files are processed before proceeding


### PR DESCRIPTION
This pull request updates the URLs used in two controllers to ensure they point to the correct endpoints for navigation. 

URL updates:

* [`feature-tracker/src/utils/tasks/web/claudeStrings/controller.js`](diffhunk://#diff-ee378e4b42dda6c689721b836bce93155f6ff0801a65a40dbcd607049503a87cL58-R58): Updated the URL in the `claudeStringsController` function to navigate to `https://claude.ai/new` instead of `https://claude.ai/`.
* [`feature-tracker/src/utils/tasks/web/perplexityStrings/controller.js`](diffhunk://#diff-f5c24c4181eeba23c82532e0a1742099dde8e2a9d456f70266e91e0e087fe2c0L58-R58): Updated the URL in the `perplexityStringsController` function to navigate to `https://www.perplexity.ai/` instead of `https://perplexity.ai/`.